### PR TITLE
Update Keyboardio listing

### DIFF
--- a/2 - In our portfolio.md
+++ b/2 - In our portfolio.md
@@ -47,7 +47,7 @@ Founders are our customers. In order of our announced participation:
 | [Zaid Al Hamami](https://www.linkedin.com/pub/zaid-al-hamami/2/83/211) | **[Immunio](http://immun.io/)** |
 | [Elizabeth Zalman](https://www.linkedin.com/in/elizabethzalman), [Schuyler Brown](https://www.linkedin.com/in/brownschuyler), [Justin McCarthy](https://www.linkedin.com/in/justinmccarthy) | **[StrongDM](http://www.strongdm.com/)** |
 | [David Rogier](https://www.linkedin.com/in/drogier), [Aaron Rasmussen](http://aaronrasmussen.com/) | **[MasterClass](http://masterclass.com/)** | 
-| [Jesse Vincent](https://twitter.com/obra), [Kaia Dekker](https://www.linkedin.com/in/kaiadekker) | **[Keyboard.io](http://www.keyboard.io/)** |
+| [Jesse Vincent](https://twitter.com/obra), [Kaia Dekker](https://twitter.com/quince) | **[Keyboardio](http://keyboard.io/)** |
 | [Edith Harbaugh](https://www.linkedin.com/in/edithharbaugh), [John Kodumal](https://www.linkedin.com/in/jkodumal) | **[LaunchDarkly](http://launchdarkly.com/)** |
 | [Nick Elprin](https://www.linkedin.com/pub/nick-elprin/38/a0/b3), [Chris Yang](https://www.linkedin.com/pub/christopher-yang/58/9a6/a62), [Matthew Granade] (https://www.linkedin.com/pub/matthew-granade/0/188/837) | **[Domino Data Lab](https://www.dominodatalab.com/)** |
 | [Chris Kelly](https://www.linkedin.com/in/christopherkelly) | **[Survata](https://www.survata.com/)** |


### PR DESCRIPTION
Point at Kaia's Twitter, rather than LinkedIn. 
Remove . from "Keyboardio"
Point to http://keyboard.io, rather than http://www.keyboard.io (which is closer to right for us)