### PR TITLE
PR: To add Sapiengraph to Bloomberg Beta's portfolio

### DIFF
--- a/2 - In our portfolio.md
+++ b/2 - In our portfolio.md
@@ -130,5 +130,6 @@ Founders are our customers. In order of our announced participation:
 | [Gadi Shamia](https://www.linkedin.com/in/gadis/), [Ben Gleitzman](https://www.linkedin.com/in/gleitz/)| **[Replicant](http://www.replicant.ai/)**|
 | [Vikram Chandra](https://www.linkedin.com/in/vikram-chandra/), [Borislav Iordanov](https://www.linkedin.com/in/borislav-iordanov-17a1152/)| **[Granthika](https://granthika.co/)**|
 | [Danielle Baskin](https://www.linkedin.com/in/danielle-baskin/), [Max Hawkins](https://www.linkedin.com/in/maxhawkins/)| **[Dialup](https://dialup.com/)**|
+| [Steven Goh](https://www.linkedin.com/in/steven-goh-6738131b/) | **[Sapiengraph](https://nubela.co/proxycurl)** |
 
 <sup>*</sup> Acquired :thumbsup:


### PR DESCRIPTION
Quoting:

> Write an interesting headline. Tell us you read this…sentence…right…here.

---

I am Steven Goh of Sapiengraph. In my budding 20s armed with a sense of invincibility:
* I served the special forces as a SEALS soldier
* Was arrested for managing a botnet
* Built apps used by more than a million users around the world

As a father in my 30s now, ~~alone myself~~ together with my team, **we** built a cryptocurrency exchange before it was cool, and exited from the venture. And it is the best feeling ever.

Venture capital is scarce in this part of the world, Singapore. And yet our tech powers US startups, such as Diffbot, for which Bloomberg Beta has funded.

We believe every application built from 2019 on, will be an AI application. We want to do for AI what AWS did for servers. We are building an AWS that supplies data for AI applications.

We are not just saying it. The code is written, the knowledge graph is being assembled, and we are post-revenue. And I am raising a seed round. And it should be Bloomberg Beta for two reasons.

1. Every hedge fund that we have approached locally in our sales outreach is using Bloomberg
2. I PERSONALLY want you guys to invest in us because 
    * Github (!!)
    * Reading the manual lit many positive signals in my brain. I need an enlightened investor to partner in this journey.

Shall we grab a video call?